### PR TITLE
feat: selectable PHP version per app (8.2–8.5), default 8.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,22 @@ Nginx Proxymanager default login information:
 
 <!-- PHP Extensions -->
 
+## :elephant: PHP Version
+
+Each app picks its own PHP version. `ez laravel new` asks for it and stores
+`PHP_VERSION` in the app's `env/app.env`.
+
+- **Supported:** `8.2`, `8.3`, `8.4`, `8.5`
+- **Default:** `8.5` (just press Enter at the prompt)
+
+To change an existing app's PHP version, edit `PHP_VERSION` in
+`apps/<app>/env/app.env` and rebuild (`ez laravel deploy ...`). Apps created
+before this feature have no `PHP_VERSION` key and continue to build on `8.3`.
+
+> Note: OPcache ships compiled into PHP 8.5+, whereas 8.2–8.4 provide it as a
+> separate module — the Dockerfiles handle this automatically, so every
+> supported version builds with the same extension set.
+
 ## :heavy_plus_sign: PHP Extensions
 
 I have installed the minimum PHP plugins required to run Laravel (marked by ✔) in the container. You should add others based on your project's needs. Add them in `laravel.Dockerfile`.

--- a/ez
+++ b/ez
@@ -879,6 +879,25 @@ validate_environment() {
   esac
 }
 
+# Validate PHP version (must be one of the officially supported versions)
+# Args: $1 - PHP version (e.g. 8.3)
+# Returns: 0 if valid, 1 if invalid
+validate_php_version() {
+  local version="$1"
+
+  case "$version" in
+    8.2|8.3|8.4|8.5)
+      return 0
+      ;;
+    *)
+      if [ "${TEST_MODE:-0}" != "1" ]; then
+        echo "[ERROR] Invalid PHP version: $version. Must be one of: 8.2, 8.3, 8.4, 8.5" >&2
+      fi
+      return 1
+      ;;
+  esac
+}
+
 # Validate Git URL format
 # Args: $1 - Git URL
 # Returns: 0 if valid, 1 if invalid
@@ -1612,10 +1631,20 @@ ez_laravel_new_command() {
     LARAVEL_ROOT="${LARAVEL_ROOT}/"
   fi
 
+  log_info "PHP version for this app (supported: 8.2, 8.3, 8.4, 8.5)"
+  while true; do
+    PHP_VERSION=$(ask_question "Enter the PHP version" "8.5")
+    if validate_php_version "$PHP_VERSION"; then
+      break
+    fi
+    log_error "Invalid PHP version: $PHP_VERSION. Must be one of: 8.2, 8.3, 8.4, 8.5"
+  done
+
   cat <<EOL > "$APP_DIR/env/app.env"
 APP_NAME=$APP_NAME
 GIT_URL=$GIT_URL
 LARAVEL_ROOT=$LARAVEL_ROOT
+PHP_VERSION=$PHP_VERSION
 OWNER_USER_NAME=$OWNER_USER_NAME
 OWNER_USER_ID=$OWNER_USER_ID
 OWNER_GROUP_NAME=$OWNER_GROUP_NAME

--- a/src/laravel_new_command.sh
+++ b/src/laravel_new_command.sh
@@ -88,10 +88,20 @@ if [[ -n "$LARAVEL_ROOT" && "$LARAVEL_ROOT" != */ ]]; then
   LARAVEL_ROOT="${LARAVEL_ROOT}/"
 fi
 
+log_info "PHP version for this app (supported: 8.2, 8.3, 8.4, 8.5)"
+while true; do
+  PHP_VERSION=$(ask_question "Enter the PHP version" "8.5")
+  if validate_php_version "$PHP_VERSION"; then
+    break
+  fi
+  log_error "Invalid PHP version: $PHP_VERSION. Must be one of: 8.2, 8.3, 8.4, 8.5"
+done
+
 cat <<EOL > "$APP_DIR/env/app.env"
 APP_NAME=$APP_NAME
 GIT_URL=$GIT_URL
 LARAVEL_ROOT=$LARAVEL_ROOT
+PHP_VERSION=$PHP_VERSION
 OWNER_USER_NAME=$OWNER_USER_NAME
 OWNER_USER_ID=$OWNER_USER_ID
 OWNER_GROUP_NAME=$OWNER_GROUP_NAME

--- a/src/lib/input_validator.sh
+++ b/src/lib/input_validator.sh
@@ -45,6 +45,25 @@ validate_environment() {
   esac
 }
 
+# Validate PHP version (must be one of the officially supported versions)
+# Args: $1 - PHP version (e.g. 8.3)
+# Returns: 0 if valid, 1 if invalid
+validate_php_version() {
+  local version="$1"
+
+  case "$version" in
+    8.2|8.3|8.4|8.5)
+      return 0
+      ;;
+    *)
+      if [ "${TEST_MODE:-0}" != "1" ]; then
+        echo "[ERROR] Invalid PHP version: $version. Must be one of: 8.2, 8.3, 8.4, 8.5" >&2
+      fi
+      return 1
+      ;;
+  esac
+}
+
 # Validate Git URL format
 # Args: $1 - Git URL
 # Returns: 0 if valid, 1 if invalid

--- a/template/common-laravel.yml
+++ b/template/common-laravel.yml
@@ -7,6 +7,7 @@ services:
       args:
         - APP_ENV=${APP_ENV}
         - LARAVEL_ROOT=${LARAVEL_ROOT}
+        - PHP_VERSION=${PHP_VERSION:-8.3}
         - OWNER_USER_ID=${OWNER_USER_ID}
         - OWNER_GROUP_ID=${OWNER_GROUP_ID}
     environment:

--- a/template/laravel-dev.Dockerfile
+++ b/template/laravel-dev.Dockerfile
@@ -1,4 +1,7 @@
-FROM php:8.3-fpm
+# PHP version (supported: 8.2, 8.3, 8.4, 8.5). Passed as a build arg from the
+# app's env; defaults to 8.3 so pre-existing apps rebuild unchanged.
+ARG PHP_VERSION=8.3
+FROM php:${PHP_VERSION}-fpm
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -36,10 +39,14 @@ RUN apt-get update && apt-get install -y \
 RUN docker-php-ext-configure gd --with-freetype=/usr/include/
 
 # Install PHP extensions
+# NOTE: opcache is compiled into PHP 8.5+, but is a separately-installable shared
+# module on 8.2-8.4, so only install it when it isn't already present.
 # RUN pecl install -o -f redis &&  rm -rf /tmp/pear &&  docker-php-ext-enable redis
-RUN docker-php-ext-install opcache exif pdo pdo_mysql zip gd intl pcntl sockets bcmath \
-    && docker-php-ext-configure pcntl --enable-pcntl \
-    && docker-php-ext-enable opcache exif
+RUN docker-php-ext-install exif pdo pdo_mysql zip gd intl pcntl sockets bcmath \
+    && docker-php-ext-enable exif \
+    && if ! php -m | grep -qi 'Zend OPcache'; then \
+         docker-php-ext-install opcache && docker-php-ext-enable opcache; \
+       fi
 
 
 RUN curl -sLS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer \

--- a/template/laravel-test.Dockerfile
+++ b/template/laravel-test.Dockerfile
@@ -1,5 +1,9 @@
+# PHP version (supported: 8.2, 8.3, 8.4, 8.5). Passed as a build arg from the
+# app's env; defaults to 8.3 so pre-existing apps rebuild unchanged.
+ARG PHP_VERSION=8.3
+
 # === Stage 1: Builder ===
-FROM php:8.3-fpm AS builder
+FROM php:${PHP_VERSION}-fpm AS builder
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -57,7 +61,7 @@ RUN npm run build;
 
 
 # === Stage 2: Final Image ===
-FROM php:8.3-fpm
+FROM php:${PHP_VERSION}-fpm
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -93,10 +97,14 @@ RUN apt-get update && apt-get install -y \
 RUN docker-php-ext-configure gd --with-freetype=/usr/include/
 
 # Install PHP extensions
+# NOTE: opcache is compiled into PHP 8.5+, but is a separately-installable shared
+# module on 8.2-8.4, so only install it when it isn't already present.
 # RUN pecl install -o -f redis &&  rm -rf /tmp/pear &&  docker-php-ext-enable redis
-RUN docker-php-ext-install opcache exif pdo pdo_mysql zip gd intl pcntl opcache sockets bcmath \
-    && docker-php-ext-configure pcntl --enable-pcntl \
-    && docker-php-ext-enable opcache exif
+RUN docker-php-ext-install exif pdo pdo_mysql zip gd intl pcntl sockets bcmath \
+    && docker-php-ext-enable exif \
+    && if ! php -m | grep -qi 'Zend OPcache'; then \
+         docker-php-ext-install opcache && docker-php-ext-enable opcache; \
+       fi
 
 #Clean apt
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/template/laravel.Dockerfile
+++ b/template/laravel.Dockerfile
@@ -1,5 +1,9 @@
+# PHP version (supported: 8.2, 8.3, 8.4, 8.5). Passed as a build arg from the
+# app's env; defaults to 8.3 so pre-existing apps rebuild unchanged.
+ARG PHP_VERSION=8.3
+
 # === Stage 1: Builder ===
-FROM php:8.3-fpm AS builder
+FROM php:${PHP_VERSION}-fpm AS builder
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -66,7 +70,7 @@ RUN npm run build;
 
 
 # === Stage 2: Final Image ===
-FROM php:8.3-fpm
+FROM php:${PHP_VERSION}-fpm
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -104,10 +108,14 @@ RUN apt-get update && apt-get install -y \
 RUN docker-php-ext-configure gd --with-freetype=/usr/include/
 
 # Install PHP extensions
+# NOTE: opcache is compiled into PHP 8.5+, but is a separately-installable shared
+# module on 8.2-8.4, so only install it when it isn't already present.
 # RUN pecl install -o -f redis &&  rm -rf /tmp/pear &&  docker-php-ext-enable redis
-RUN docker-php-ext-install opcache exif pdo pdo_mysql zip gd intl pcntl sockets bcmath \
-    && docker-php-ext-configure pcntl --enable-pcntl \
-    && docker-php-ext-enable opcache exif
+RUN docker-php-ext-install exif pdo pdo_mysql zip gd intl pcntl sockets bcmath \
+    && docker-php-ext-enable exif \
+    && if ! php -m | grep -qi 'Zend OPcache'; then \
+         docker-php-ext-install opcache && docker-php-ext-enable opcache; \
+       fi
 
 #Clean apt
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
Makes the PHP version configurable per app instead of hardcoding 8.3.

- `ez laravel new` prompts for the PHP version (default 8.5), validates it against the supported set (8.2, 8.3, 8.4, 8.5) via a new validate_php_version, and stores PHP_VERSION in the app's env/app.env.
- Threaded as a build arg through common-laravel.yml (PHP_VERSION=${PHP_VERSION:-8.3}) into all three Dockerfiles, which now use ARG PHP_VERSION + FROM php:${PHP_VERSION}-fpm.
- OPcache is compiled into PHP 8.5+ but is a shared module on 8.2–8.4, which broke `docker-php-ext-install opcache` on 8.5. The extension step now installs opcache only when it isn't already built in, so every supported version builds with the same extension set. (Also dropped a redundant post-install pcntl reconfigure.)

Backward compatible: apps with no PHP_VERSION key build on 8.3 as before.

Verified by real Docker builds on php:8.5-fpm (opcache built-in, skipped) and php:8.3-fpm (opcache installed) — both produce the full extension set. ez recompiled from src (bashly 1.3.3, in sync).